### PR TITLE
Fix OAuth and OAuth2 generators

### DIFF
--- a/src/content/js/restclient.main.js
+++ b/src/content/js/restclient.main.js
@@ -755,8 +755,8 @@ restclient.main = {
           oauth2 = JSON.parse(oauth2);
           restclient.oauth2.setAuthorize(oauth2.authorize);
           restclient.oauth2.setTokens(oauth2.tokens);
-          $('#window-oauth2').show();
-          $('#window-oauth2 .nav-tabs li a').eq(1).click();
+          $('#nodal-oauth2').show();
+          $('#nodal-oauth2 .nav-tabs li a').eq(1).click();
         }catch(e) {}
         return;
       }
@@ -1730,7 +1730,7 @@ restclient.main = {
       autoRealm(true);
     }
     
-    $('#oauth-setting .btnOkay').click(function () {
+    $('#modal-oauth .save').click(function () {
       
       if (!oauth_realm.hasClass('disabled') 
             && (oauth_realm.val().indexOf('?') > -1 || oauth_realm.val().indexOf('#') > -1))
@@ -1751,25 +1751,12 @@ restclient.main = {
       param.oauth_realm             = oauth_realm.val();
       
       restclient.setPref('OAuth.setting', JSON.stringify(param));
-      
-      var message = restclient.message.show({
-        id: 'alert-oauth-setting-saved',
-        parent: $('#oauth-setting .infobar'),
-        exclude: true,
-        type: 'message',
-        title: 'OAuth settings saved!',
-        message: 'Your OAuth settings have been successfully saved. Enjoy.',
-        buttons: [
-          {title: 'Close', class: 'btn-danger', 'timeout': 5000, callback: function () { $('#alert-oauth-setting-saved').alert('close'); }}
-        ]
-      });
     });
 
     disable_oauth_realm.click(disableRealm);
     auto_oauth_realm.click(autoRealm);
     auto_oauth_timestamp.click(autoTimeStamp);
     auto_oauth_nonce.click(autoNonce);
-
 
     //Load oauth keys from preferences
     var sign_consumer_key         = $('#signature-request [name="consumer_key"]'),
@@ -1793,7 +1780,7 @@ restclient.main = {
       (sign.remember === true) ? sign_remember.attr('checked', true) : sign_remember.removeAttr('checked');
     }
 
-    $('#signature-request .btnInsertAsHeader').bind('click', restclient.main.oauthSign);
+    $('#modal-oauth .save').bind('click', restclient.main.oauthSign);
   },
   oauthSign: function () {
     var sign_consumer_key         = $('#signature-request [name="consumer_key"]'),
@@ -1811,10 +1798,14 @@ restclient.main = {
         auto_oauth_realm          = $('#oauth-setting [name="auto_oauth_realm"]'),
         oauth_realm               = $('#oauth-setting [name="oauth_realm"]'),
         disable_oauth_realm       = $('#oauth-setting [name="disable_oauth_realm"]'),
-            
-        sign_okay                 = $('#signature-request .btnOkay'),
+
+        btn                       = $(this),
 
         errors = [];
+
+    if (!btn.hasClass('btn-success')) {
+        btn = $('#insert-oauth');
+    }
 
     if (sign_consumer_key.val() == '') {
       sign_consumer_key.parents('.control-group').addClass('error');
@@ -1838,7 +1829,7 @@ restclient.main = {
       $('#signature-request .error-info').hide();
     }
 
-    sign_okay.button('loading');
+    btn.button('loading');
     
     if (sign_remember.attr('checked') == 'checked') {
       var setting = {
@@ -1916,34 +1907,88 @@ restclient.main = {
       else
         param.realm = oauth_realm.val();
     }
-    //console.warn(param);
-    var headerId = restclient.main.addHttpRequestHeader('Authorization', headerValue, param);
-    //restclient.log('header id of oauth header: ' + headerId);
+
     $('#window-oauth').css('display', 'none');
 
-    if (restclient.getPref('sign-warning', '') == '')
-      var message = restclient.message.show({
-        id: 'alert-oauth-sign',
-        type: 'warning',
-        class: 'span5 offset3',
-        title: 'Notice',
-        message: 'Do you want RESTClient to refresh OAuth signature before sending your request?',
-        buttons: [
-          [
-            {title: 'Yes, please', class: 'btn-danger', callback: function () { restclient.main.setOAuthAutoRefresh(headerId, true); $('#alert-oauth-sign').alert('close'); }},
-            {title: 'Yes, and please remember my descision', callback: function () { restclient.main.setOAuthAutoRefresh(headerId, true); restclient.setPref('OAuth.refresh', "yes");  restclient.setPref('sign-warning', 'false'); $('#alert-oauth-sign').alert('close');}}
-          ],
-          [
-            {title: 'No, thanks', class: 'btn-warning', callback: function () { restclient.main.setOAuthAutoRefresh(headerId, false); $('#alert-oauth-sign').alert('close'); }},
-            {title: 'No, and please don\'t remind me again', callback: function () { restclient.main.setOAuthAutoRefresh(headerId, false); restclient.setPref('OAuth.refresh', "no"); restclient.setPref('sign-warning', 'false'); $('#alert-oauth-sign').alert('close'); }}
-          ]
-        ]
-      });
-    else
+    if ($(this).hasClass('insertHeader'))
     {
-      var autoRefresh = restclient.getPref('OAuth.refresh', "yes");
-      restclient.main.setOAuthAutoRefresh(headerId, (autoRefresh === 'yes'));
+      //console.warn(param);
+      var headerId = restclient.main.addHttpRequestHeader('Authorization', headerValue, param);
+      //restclient.log('header id of oauth header: ' + headerId);
+
+      if (restclient.getPref('sign-warning', '') == '') {
+        var message = restclient.message.show({
+          id: 'alert-oauth-sign',
+          type: 'warning',
+          class: 'span5 offset3',
+          title: 'Notice',
+          message: 'Do you want RESTClient to refresh OAuth signature before sending your request?',
+          buttons: [
+            [
+              {
+                title: 'Yes, please', class: 'btn-danger', callback: function () {
+                  restclient.main.setOAuthAutoRefresh(headerId, true);
+                  $('#alert-oauth-sign').alert('close');
+                }
+              },
+              {
+                title: 'Yes, and please remember my descision', callback: function () {
+                  restclient.main.setOAuthAutoRefresh(headerId, true);
+                  restclient.setPref('OAuth.refresh', "yes");
+                  restclient.setPref('sign-warning', 'false');
+                  $('#alert-oauth-sign').alert('close');
+                }
+              }
+            ],
+            [
+              {
+                title: 'No, thanks', class: 'btn-warning', callback: function () {
+                  restclient.main.setOAuthAutoRefresh(headerId, false);
+                  $('#alert-oauth-sign').alert('close');
+                }
+              },
+              {
+                title: 'No, and please don\'t remind me again', callback: function () {
+                  restclient.main.setOAuthAutoRefresh(headerId, false);
+                  restclient.setPref('OAuth.refresh', "no");
+                  restclient.setPref('sign-warning', 'false');
+                  $('#alert-oauth-sign').alert('close');
+                }
+              }
+            ]
+          ]
+        });
+      }
+      else {
+        var autoRefresh = restclient.getPref('OAuth.refresh', "yes");
+        restclient.main.setOAuthAutoRefresh(headerId, (autoRefresh === 'yes'));
+      }
     }
+    else {
+      var signatureString = restclient.oauth.normalizeToString(),
+          requestUrl = $('#request-url'),
+          newRequestString = requestUrl.val().contains('?') ? '&' : '?';
+
+      newRequestString += signatureString;
+
+      requestUrl.val(requestUrl.val() + newRequestString);
+    }
+
+
+    var message = restclient.message.show({
+      id: 'alert-oauth-setting-saved',
+      parent: $('#modal-oauth .infobar'),
+      class: 'alert-success',
+      exclude: true,
+      type: 'message',
+      title: 'OAuth settings saved!',
+      message: 'Your OAuth settings have been successfully saved. Enjoy.',
+      buttons: [
+        {title: 'Close', class: 'btn-danger', 'timeout': 5000, callback: function () {$('#alert-oauth-setting-saved').alert('close'); }}
+      ]
+    });
+
+    btn.button('reset');
   },
   setOAuthAutoRefresh: function (headerId, auto) {
     $('[data-header-id="' + headerId + '"]').attr('auto-refresh', (auto) ? "yes" : "no");

--- a/src/content/js/restclient.message.js
+++ b/src/content/js/restclient.message.js
@@ -96,9 +96,9 @@ restclient.message = {
     }
     else{
       $('.messages-overlay').show();
-      container.appendTo('.messages-overlay .container');
+      container.appendTo('.messages-overlay .container-fluid');
       $('#' + id).bind('closed', function () {
-        if($('.messages-overlay .container').find('.alert').length == 1) {
+        if($('.messages-overlay .container-fluid').find('.alert').length == 1) {
           $('.messages-overlay').hide();
         }
 

--- a/src/content/js/restclient.oauth.js
+++ b/src/content/js/restclient.oauth.js
@@ -59,7 +59,7 @@ restclient.oauth = {
 
     return {
         parameters: this._parameters,
-        signature: this.oauthEscape(oauth_signature),
+        signature: oauth_signature,
         signed_url: this._path + '?' + this.normalizeToString(),
         headerString: this.getHeaderString()
     };

--- a/src/content/js/restclient.oauth2.js
+++ b/src/content/js/restclient.oauth2.js
@@ -91,7 +91,7 @@ restclient.oauth2 = {
     param.oauth2.authorize = restclient.oauth2.getAuthorize();
     param.oauth2.tokens = restclient.oauth2.getTokens();
     
-    restclient.main.addHttpRequestHeader('Authorization', 'OAuth2 ' + access_token.val(), param);
+    restclient.main.addHttpRequestHeader('Authorization', 'Bearer ' + access_token.val(), param);
     $('#modal-oauth2').modal('hide');
   },
   insertAsQueryString: function() {

--- a/src/content/js/restclient.oauth2.js
+++ b/src/content/js/restclient.oauth2.js
@@ -35,17 +35,17 @@ restclient.oauth2 = {
     $('#oauth2-authorize [name="templates"]').change(restclient.oauth2.applyTemplate);
     $('#oauth2-tokens [name="saved_tokens"]').change(restclient.oauth2.applyToken);
     
-    $('#window-oauth2 .btnClose').click(restclient.oauth2.closeDialog);
-    $('#window-oauth2 .btnAuthorize').click(restclient.oauth2.authorize);
-    $('#window-oauth2 .btnInsertAsHeader').click(restclient.oauth2.insertAsHeader);
-    $('#window-oauth2 .btnInsertAsQueryString').click(restclient.oauth2.insertAsQueryString);
+    $('#modal-oauth2 .btnClose').click(restclient.oauth2.closeDialog);
+    $('#modal-oauth2 .btnAuthorize').click(restclient.oauth2.authorize);
+    $('#modal-oauth2 .btnInsertAsHeader').click(restclient.oauth2.insertAsHeader);
+    $('#modal-oauth2 .btnInsertAsQueryString').click(restclient.oauth2.insertAsQueryString);
     
-    $('#window-oauth2 .btnSaveTemplate').click(restclient.oauth2.saveTemplate);
-    $('#window-oauth2 .btnRemoveTemplate').click(restclient.oauth2.removeTemplate);
+    $('#modal-oauth2 .btnSaveTemplate').click(restclient.oauth2.saveTemplate);
+    $('#modal-oauth2 .btnRemoveTemplate').click(restclient.oauth2.removeTemplate);
     
-    $('#window-oauth2 .btnSaveToken').click(restclient.oauth2.saveToken);
-    $('#window-oauth2 .btnRemoveToken').click(restclient.oauth2.removeToken);
-    $('#window-oauth2 .btnRefreshToken').click(restclient.oauth2.doRefreshToken);
+    $('#modal-oauth2 .btnSaveToken').click(restclient.oauth2.saveToken);
+    $('#modal-oauth2 .btnRemoveToken').click(restclient.oauth2.removeToken);
+    $('#modal-oauth2 .btnRefreshToken').click(restclient.oauth2.doRefreshToken);
   },
   updateTemplateList: function() {
     $('#oauth2-authorize [name="templates"]').empty();
@@ -73,7 +73,7 @@ restclient.oauth2 = {
     $('#modal-oauth2').modal('show');
   },
   closeDialog: function() {
-    $('#window-oauth2').hide();
+    $('#modal-oauth2').modal('hide');
     restclient.oauth2.listener.param = false;
   },
   insertAsHeader: function() {
@@ -92,7 +92,7 @@ restclient.oauth2 = {
     param.oauth2.tokens = restclient.oauth2.getTokens();
     
     restclient.main.addHttpRequestHeader('Authorization', 'OAuth2 ' + access_token.val(), param);
-    $('#window-oauth2').hide();
+    $('#modal-oauth2').modal('hide');
   },
   insertAsQueryString: function() {
     var access_token    = $('#oauth2-tokens [name="access_token"]');
@@ -104,7 +104,7 @@ restclient.oauth2 = {
     }
     var url = $('#request-url').val();
     $('#request-url').val(restclient.helper.setParam(url, 'access_token', access_token.val()));
-    $('#window-oauth2').hide();
+    $('#modal-oauth2').modal('hide');
   },
   getAuthorize: function() {
     var response_type           = $('#oauth2-authorize [name="response_type"]'),
@@ -235,9 +235,9 @@ restclient.oauth2 = {
       restclient.oauth2.updateTokenList();
       $('#modal-oauth2-save').modal('hide');
     });
-    $('#window-oauth2').hide();
+    $('#modal-oauth2').modal('hide');
     
-    $('#modal-oauth2-save').modal('show').on('hidden', function(){ $('#window-oauth2').show(); });
+    $('#modal-oauth2-save').modal('show').on('hidden', function(){ $('#modal-oauth2').show(); });
   },
   removeToken: function() {
     var template = $('#oauth2-tokens [name="saved_tokens"]');
@@ -314,9 +314,9 @@ restclient.oauth2 = {
       restclient.oauth2.updateTemplateList();
       $('#modal-oauth2-save').modal('hide');
     });
-    $('#window-oauth2').hide();
+    $('#modal-oauth2').modal('hide');
     
-    $('#modal-oauth2-save').modal('show').on('hidden', function(){ $('#window-oauth2').show(); });
+    $('#modal-oauth2-save').modal('show').on('hidden', function(){ $('#modal-oauth2').show(); });
   },
   removeTemplate: function() {
     var template = $('#oauth2-authorize [name="templates"]');
@@ -461,7 +461,7 @@ restclient.oauth2 = {
       return false;
     }
     
-    var btnAuthorize = $('#window-oauth2 .btnAuthorize');
+    var btnAuthorize = $('#modal-oauth2 .btnAuthorize');
     var xhr = new XMLHttpRequest();
     xhr.addEventListener('readystatechange', function(event) {
       if (xhr.readyState == 4) {
@@ -488,7 +488,7 @@ restclient.oauth2 = {
           restclient.log(xhr.responseText);
           restclient.log(accessToken);
           restclient.oauth2.setTokens(accessToken);
-          $('#window-oauth2 .nav-tabs li a').eq(1).click();
+          $('#modal-oauth2 .nav-tabs li a').eq(1).click();
           return;
         }
       }
@@ -559,7 +559,7 @@ restclient.oauth2 = {
           restclient.log(xhr.responseText);
           console.error(tokens);
           restclient.oauth2.setTokens(tokens);
-          $('#window-oauth2 .nav-tabs li a').eq(1).click();
+          $('#modal-oauth2 .nav-tabs li a').eq(1).click();
           return;
         }
       }

--- a/src/content/restclient.html
+++ b/src/content/restclient.html
@@ -388,6 +388,7 @@
     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
     <h3>OAuth</h3>
   </div>
+  <div class="infobar" style="width: 85%; margin: 0 auto;"></div>
   <div class="modal-body">
     <ul class="nav nav-tabs">
       <li class="active"><a href="#signature-request" data-toggle="tab">Signature for this request</a></li>
@@ -424,7 +425,6 @@
       </div><!-- end of signature-request panel //-->
       <div class="tab-pane" id="oauth-setting">
         <form class="form-horizontal" onsubmit="return false;">
-          <div class="infobar" style="width: 85%; margin: 0 auto;"></div>
           <div class="control-group">
             <label class="control-label" for="oauth_signature_method">Signature Methods</label>
             <div class="controls">
@@ -478,16 +478,16 @@
       <input type="checkbox" name="remember"> Remember the setting
     </label>
     <div class="btn-group dropup">
-      <button class="btn btn-success">Insert</button>
+      <button class="btn btn-success save insertHeader" id="insert-oauth">Insert</button>
       <button class="btn btn-success dropdown-toggle" data-toggle="dropdown">
         <span class="caret"></span>
       </button>
       <ul class="dropdown-menu pull-right">
-        <li><a href="#">Insert as header</a></li>
-        <li><a href="#">Insert as query string</a></li>
+        <li><a href="#" class="save insertHeader">Insert as header</a></li>
+        <li><a href="#" class="save insertQuery">Insert as query string</a></li>
       </ul>
     </div>
-    <a href="#" class="btn btn-success">Save changes</a>
+    <a href="#" class="btn btn-success save" id="save-oauth">Save changes</a>
     <a href="#" class="btn" data-dismiss="modal" aria-hidden="true">Close</a>
   </div>
 </div>


### PR DESCRIPTION
Sorry for the delay. Had to redo the whole fix because I couldn't really find what I changed in "real" code amongst all those formatting changes my IDE performed.

Changed the OAuth dialog a little. The "alert"-messages are now appearing right below the modal window's headline instead of inside the settings tab. The success notification is now green instead of red and will only appear if the generation was really successful.

OAuth2 will now properly close it's modal window via the bootstrap modal() method instead of just hiding the overlay div and rendering the whole addon unusable.

OAuth insert as Query String and insert as Header are working properly. Default action for the insert button is insert as Header.

OAuth signing will not URLEncode the signature string (that previous default was breaking the signature string).

OAuth was tested with Twitter and OAuth2 with facebook. Both seem to work. Haven't tested any other services so far.

That's all I changed, or at least all I can remember.

Kind regards,
Benedikt